### PR TITLE
Add rostopic interface and fix status update

### DIFF
--- a/ros/src/util/packages/autoware_launcher/src/autoware_launcher/core/basetree.py
+++ b/ros/src/util/packages/autoware_launcher/src/autoware_launcher/core/basetree.py
@@ -97,6 +97,11 @@ class AwBaseNode(object):
         for child in self.children(): result.extend(child.listnode(True))
         return result
 
+    def listparent(self, this = False):
+        result = [self] if this else []
+        if self.__parent: result.extend(self.__parent.listparent(True))
+        return result
+
 
 class AwBaseTree(AwBaseNode):
 

--- a/ros/src/util/packages/autoware_launcher/src/autoware_launcher/core/launch.py
+++ b/ros/src/util/packages/autoware_launcher/src/autoware_launcher/core/launch.py
@@ -131,6 +131,15 @@ class AwLaunchNode(basetree.AwBaseNode):
         else:
             return self.__term()
 
+    def update_exec_status(self):
+        status = self.STOP
+        for child in self.children():
+            status |= child.status
+        if self.status != status:
+            self.status = status
+            return True
+        return False
+
     def __exec(self):
         if self.plugin.isleaf():
             if self.status == self.STOP:

--- a/ros/src/util/packages/autoware_launcher/src/autoware_launcher/core/rostopic.py
+++ b/ros/src/util/packages/autoware_launcher/src/autoware_launcher/core/rostopic.py
@@ -1,0 +1,27 @@
+import logging
+import rospy
+import std_msgs
+
+logger = logging.getLogger(__name__)
+
+
+class RosTopicAdapter(object):
+
+    def __init__(self):
+        rospy.init_node("autoware_launcher")
+        self.__pub = rospy.Publisher("/autoware_launcher/callback", std_msgs.msg.String, queue_size=10)
+
+    def profile_updated(self):
+        self.__pub.publish(std_msgs.msg.String(data="profile_updated"))
+
+    def node_updated(self, lpath):
+        self.__pub.publish(std_msgs.msg.String(data="node_updated {}".format(lpath)))
+
+    def node_created(self, lpath):
+        self.__pub.publish(std_msgs.msg.String(data="node_created {}".format(lpath)))
+
+    def node_removed(self, lpath):
+        self.__pub.publish(std_msgs.msg.String(data="node_removed {}".format(lpath)))
+
+    def status_updated(self, lpath, state):
+        self.__pub.publish(std_msgs.msg.String(data="status_updated {} {}".format(lpath, state)))

--- a/ros/src/util/packages/autoware_launcher/src/autoware_launcher/gui/client.py
+++ b/ros/src/util/packages/autoware_launcher/src/autoware_launcher/gui/client.py
@@ -206,6 +206,3 @@ class AwQtGuiClient(object):
 
     def update_node(self, lpath, ldata):
         return self.__server.update_node(lpath, ldata)
-
-
-

--- a/ros/src/util/packages/autoware_launcher/src/autoware_launcher/gui_operator/context.py
+++ b/ros/src/util/packages/autoware_launcher/src/autoware_launcher/gui_operator/context.py
@@ -1,6 +1,7 @@
 from autoware_launcher.core import AwLaunchServer, AwLaunchClientIF
 from autoware_launcher.core.launch import AwLaunchNode
 from autoware_launcher.core import myutils
+from autoware_launcher.core.rostopic import RosTopicAdapter
 import os
 
 class Context(object):
@@ -30,6 +31,8 @@ class Context(object):
 
         self.node_status_watcher = NodeStatusWatcher()
         self.server.register_client(self.node_status_watcher)
+
+        self.server.register_client(RosTopicAdapter())
 
     def set_map_profile(self, mp):
         self.map_profile = mp


### PR DESCRIPTION
RosTopicで実行状態を通知するようにしました。
また、子ノードの実行状態に親ノードが追従するように修正しました。

AwLaunchServer作ってるところで、
クライアントとして登録してもらえればrostopicで通知を送信します。
```
from autoware_launcher.core.rostopic import RosTopicAdapter
server.register_client(RosTopicAdapter())
```